### PR TITLE
Remove IOC *.cmd comment about loading envPaths

### DIFF
--- a/iocs/pcoIOC/iocBoot/iocPCO/PCO_st64.cmd
+++ b/iocs/pcoIOC/iocBoot/iocPCO/PCO_st64.cmd
@@ -1,5 +1,3 @@
-
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
 < envPaths64
 
 

--- a/iocs/pcoIOC/iocBoot/iocPCO/PCO_st64_Edge.cmd
+++ b/iocs/pcoIOC/iocBoot/iocPCO/PCO_st64_Edge.cmd
@@ -1,4 +1,3 @@
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
 < envPaths64
 
 epicsEnvSet("PREFIX",  "PCOIOC2:")


### PR DESCRIPTION
Remove an erroneous comment in PCO_st64*.cmd about needing to have
loaded envPaths via st.cmd.linux or st.cmd.win32.